### PR TITLE
Minimal postal address with line7 of AFNOR norm

### DIFF
--- a/conceptual_model/field-types.md
+++ b/conceptual_model/field-types.md
@@ -62,9 +62,10 @@ Rough implementation of the AFNOR NF Z 10-011 standard
 | line3             | string   | no       | max 38 characters
 | line4             | string   | no       | max 38 characters
 | line5             | string   | no       | max 38 characters
-| line6             | string   | yes      | max 38 characters
+| line6             | string   | no       | max 38 characters
+| line7             | string   | yes      | max 38 characters
 | source            | string   | no       | any
-| certificationDate | dstring  | no       | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+| certificationDate | string   | no       | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
 
 
 ### Phone number field

--- a/conceptual_model/field-types.md
+++ b/conceptual_model/field-types.md
@@ -57,12 +57,12 @@ Rough implementation of the AFNOR NF Z 10-011 standard
 
 | Name              | Type     | Required | Format
 | ------------------|----------|----------|---------------------------------
-| line1             | string   | yes      | max 38 characters
+| line1             | string   | no       | max 38 characters
 | line2             | string   | no       | max 38 characters
 | line3             | string   | no       | max 38 characters
 | line4             | string   | no       | max 38 characters
 | line5             | string   | no       | max 38 characters
-| line6             | string   | no       | max 38 characters
+| line6             | string   | yes      | max 38 characters
 | source            | string   | no       | any
 | certificationDate | dstring  | no       | [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
 

--- a/conceptual_model/schemas/personal-information.schema.json
+++ b/conceptual_model/schemas/personal-information.schema.json
@@ -124,9 +124,9 @@
               "maxLength": 38
             }
           },
-          "$comment": "At least first line is expected to be filled",
+          "$comment": "At least the country line is expected to be filled",
           "required": [
-            "line6"
+            "line7"
           ],
           "additionalProperties": false
         },

--- a/conceptual_model/schemas/personal-information.schema.json
+++ b/conceptual_model/schemas/personal-information.schema.json
@@ -126,7 +126,7 @@
           },
           "$comment": "At least first line is expected to be filled",
           "required": [
-            "line1"
+            "line6"
           ],
           "additionalProperties": false
         },


### PR DESCRIPTION
About address field type, there was a difference between the documentation and the json schema. In the JSON, the line7 is available. 
Moreover, the only field required was line1 whereas the line 1 corresponds to person's names.  The person's names are not mandatory to process address values.
To create an address field, I suggest to have at least the line7 field with the country. I think that the target should be the CMS account store line7/line6/line4 for a personal address. line7 (or 6 ?) is sufficient as required rules.